### PR TITLE
Change recursion result

### DIFF
--- a/api/src/main/java/net/quickwrite/fluent4j/container/FluentScope.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/container/FluentScope.java
@@ -13,8 +13,6 @@ public interface FluentScope<B extends ResultBuilder> extends Cloneable {
 
     boolean addTraversed(final FluentIdentifier<?> key);
 
-    void setTraversed(final Set<FluentIdentifier<?>> traversed);
-
     ArgumentList<B> arguments();
 
     void setArguments(final ArgumentList<B> arguments);

--- a/builder/src/test/java/net/quickwrite/fluent4j/test/RecursionTest.java
+++ b/builder/src/test/java/net/quickwrite/fluent4j/test/RecursionTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import static net.quickwrite.fluent4j.test.util.FluentUtils.getResourceFromResource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RecursionTest {
     private static final FluentBundle<ResultBuilder> bundle;
@@ -22,28 +21,33 @@ public class RecursionTest {
 
     @Test
     public void testRecursiveMessage1() {
-        // TODO: Better exception
-        assertThrows(
-                RuntimeException.class,
-                () -> bundle.resolveMessage("recursive-message1", StringResultFactory.construct())
+        assertEquals(
+                "{???}",
+                bundle.resolveMessage("recursive-message1", StringResultFactory.construct()).get().toString()
         );
     }
 
     @Test
     public void testRecursiveTerm1() {
-        // TODO: Better exception
-        assertThrows(
-                RuntimeException.class,
-                () -> bundle.resolveMessage("recursive-term1", StringResultFactory.construct())
+        assertEquals(
+                "{???}",
+                bundle.resolveMessage("recursive-term1", StringResultFactory.construct()).get().toString()
+        );
+    }
+
+    @Test
+    public void testRecursiveTerm2() {
+        assertEquals(
+                "This is a recursive {???}.",
+                bundle.resolveMessage("recursive-term2", StringResultFactory.construct()).get().toString()
         );
     }
 
     @Test
     public void testRecursiveSelector() {
-        // TODO: Better exception
-        assertThrows(
-                RuntimeException.class,
-                () -> bundle.resolveMessage("recursive-selector", StringResultFactory.construct())
+        assertEquals(
+                "Test",
+                bundle.resolveMessage("recursive-selector", StringResultFactory.construct()).get().toString()
         );
     }
 

--- a/builder/src/test/resources/recursion/recursion.ftl
+++ b/builder/src/test/resources/recursion/recursion.ftl
@@ -2,8 +2,11 @@
 ## is recursive
 recursive-message1 = { recursive-message1 }
 
-recursive-term1 = { -recursive-term1 }
--recursive-term1 = { -recursive-term1 }
+recursive-term1 = { -recursive-term }
+
+recursive-term2 = This is a recursive {-recursive-term}.
+
+-recursive-term = { -recursive-term }
 
 recursive-selector = { -recursive-selector }
 -recursive-selector = { -recursive-selector.test ->

--- a/impl/src/main/java/net/quickwrite/fluent4j/impl/ast/entry/FluentBaseElement.java
+++ b/impl/src/main/java/net/quickwrite/fluent4j/impl/ast/entry/FluentBaseElement.java
@@ -21,8 +21,8 @@ public abstract class FluentBaseElement<I, B extends ResultBuilder> implements F
     @Override
     public void resolve(final FluentScope<B> scope, final B builder) {
         if(!scope.addTraversed(identifier)) {
-            // TODO: Better exception handling
-            throw new RuntimeException("Recursive element found: '" + identifier.getFullIdentifier() + "'");
+            builder.append("{???}");
+            return;
         }
 
         for (final FluentPattern<B> pattern : patterns) {

--- a/impl/src/main/java/net/quickwrite/fluent4j/impl/ast/pattern/FluentTermReference.java
+++ b/impl/src/main/java/net/quickwrite/fluent4j/impl/ast/pattern/FluentTermReference.java
@@ -25,7 +25,6 @@ public class FluentTermReference<B extends ResultBuilder> extends ParameterizedL
     public void resolve(final FluentScope<B> scope, final B builder) {
         final FluentScope<B> clonedScope = scope.clone();
         clonedScope.setArguments(argumentList);
-        clonedScope.setTraversed(new HashSet<>(scope.traversed()));
         unwrap(scope).resolve(clonedScope, builder);
     }
 

--- a/impl/src/main/java/net/quickwrite/fluent4j/impl/container/FluentResolverScope.java
+++ b/impl/src/main/java/net/quickwrite/fluent4j/impl/container/FluentResolverScope.java
@@ -43,11 +43,6 @@ public class FluentResolverScope<B extends ResultBuilder> implements FluentScope
     }
 
     @Override
-    public void setTraversed(final Set<FluentIdentifier<?>> traversed) {
-        this.traversed = traversed;
-    }
-
-    @Override
     public boolean addTraversed(final FluentIdentifier<?> key) {
         return this.traversed.add(key);
     }
@@ -70,7 +65,11 @@ public class FluentResolverScope<B extends ResultBuilder> implements FluentScope
     @Override
     public FluentScope<B> clone() {
         try {
-            return (FluentScope<B>) super.clone();
+            final FluentResolverScope<B> newScope = (FluentResolverScope<B>) super.clone();
+
+            newScope.traversed = new HashSet<>(traversed);
+
+            return newScope;
         } catch (final CloneNotSupportedException ignored) {
             // This should NEVER happen
 


### PR DESCRIPTION
When infinite recursion was detected it previously has thrown a RuntimeException. This was better than just not handling infinite Recursion and creating a StackOverflow-Error.

Now it doesn't throw and Exception and it is just adding a `{???}` instead of the result of the term or message. This is more in line with the JavaScript implementation of Fluent.