### PR TITLE
Add JavaDocs

### DIFF
--- a/api/src/main/java/net/quickwrite/fluent4j/ast/FluentFunction.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/FluentFunction.java
@@ -5,8 +5,27 @@ import net.quickwrite.fluent4j.ast.placeable.FluentPlaceable;
 import net.quickwrite.fluent4j.container.FluentScope;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The FluentFunction interface represents a function.
+ * Functions provide additional functionality available to the
+ * localizers for formatting data or providing additional data.
+ *
+ * @param <B> The type of ResultBuilder used by the FluentFunction
+ */
 public interface FluentFunction<B extends ResultBuilder> {
+    /**
+     * Retrieves the identifier of the function.
+     *
+     * @return The identifier of the function
+     */
     String getIdentifier();
 
+    /**
+     * Evaluates the function with the given scope and argument list.
+     *
+     * @param scope        The FluentScope used for evaluating
+     * @param argumentList The ArgumentList containing the arguments passed to the function
+     * @return A FluentPlaceable representing the evaluated function
+     */
     FluentPlaceable<B> parseFunction(final FluentScope<B> scope, final ArgumentList<B> argumentList);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/FluentPattern.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/FluentPattern.java
@@ -4,8 +4,34 @@ import net.quickwrite.fluent4j.container.FluentScope;
 import net.quickwrite.fluent4j.exception.FluentPatternException;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * A pattern itself is the base element for the
+ * message. With that a pattern can be a TextElement
+ * or a {@link net.quickwrite.fluent4j.ast.placeable.FluentPlaceable}.
+ * @param <B>
+ */
 public interface FluentPattern<B extends ResultBuilder> extends FluentResolvable<B> {
+    /**
+     * Returns the element that this element links to. If the element
+     * itself for example is a Message Reference the message itself should be returned.
+     *
+     * <hr />
+     *
+     * If the element contains the necessary information directly
+     * (like a simple Text Element) this should return itself.
+     *
+     * @param scope The scope that the link should be unwrapped in
+     * @return The linked element
+     *
+     * @throws FluentPatternException If the linked element does not exist this Exception should be thrown
+     */
     FluentPattern<B> unwrap(final FluentScope<B> scope) throws FluentPatternException;
 
+    /**
+     * Returns a simple string variant of the data that this element contains
+     *
+     * @param scope The scope in which this operation should be done
+     * @return A simple string
+     */
     String toSimpleString(final FluentScope<B> scope);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/FluentResolvable.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/FluentResolvable.java
@@ -3,6 +3,15 @@ package net.quickwrite.fluent4j.ast;
 import net.quickwrite.fluent4j.container.FluentScope;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The base element for the construction of the message.
+ *
+ * @param <B> The type of ResultBuilder associated with the resolvable entity.
+ */
 public interface FluentResolvable<B extends ResultBuilder> {
+    /**
+     * @param scope The scope which contains the necessary information for this element.
+     * @param builder The ResultBuilder used for resolving the entity.
+     */
     void resolve(final FluentScope<B> scope, final B builder);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/entry/FluentEntry.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/entry/FluentEntry.java
@@ -8,10 +8,49 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Represents a single entry that is being used
+ * inside the parsed resource that holds the translation
+ * content based upon an identifier.
+ *
+ * @param <B> The type of ResultBuilder used by the FluentEntry
+ */
 public interface FluentEntry<B extends ResultBuilder> extends FluentResolvable<B>, FluentPattern<B> {
+    /**
+     * Returns the identifier of this specific entry
+     *
+     * @return The identifier
+     */
     FluentIdentifier<String> getIdentifier();
+
+    /**
+     * Returns a list of attributes that this entry has.
+     *
+     * <p>
+     *     If there are no entries this should return
+     *     an empty list.
+     * </p>
+     *
+     * @return A list of attributes
+     */
     List<FluentEntry.Attribute<B>> getAttributes();
 
+    /**
+     * Returns the specific attribute with the given
+     * identifier.
+     * <br />
+     * If the attribute doesn't exist it will return
+     * an empty optional.
+     *
+     * <p>
+     *     This search for the attribute is a linear search
+     *     with the default implementation and with that has
+     *     a time complexity of {@code O(n)}.
+     * </p>
+     *
+     * @param identifier The identifier of the attribute
+     * @return The attribute
+     */
     default Optional<FluentEntry.Attribute<B>> getAttribute(final String identifier) {
         for (final FluentEntry.Attribute<B> attribute : getAttributes()) {
             if(attribute.getIdentifier().getSimpleIdentifier().equals(identifier)) {
@@ -22,9 +61,25 @@ public interface FluentEntry<B extends ResultBuilder> extends FluentResolvable<B
         return Optional.empty();
     }
 
+    /**
+     * A single attribute of the FluentEntry.
+     *
+     * @param <B> The type of ResultBuilder used by the Attribute
+     */
     interface Attribute<B extends ResultBuilder> extends FluentResolvable<B> {
+        /**
+         * Returns the identifier of the attribute
+         *
+         * @return The identifier
+         */
         FluentIdentifier<String> getIdentifier();
 
+        /**
+         * Returns a list of patterns that are being stored inside
+         * the Attribute.
+         *
+         * @return A list of patterns
+         */
         List<FluentPattern<B>> getPatterns();
     }
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/entry/FluentMessage.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/entry/FluentMessage.java
@@ -2,5 +2,10 @@ package net.quickwrite.fluent4j.ast.entry;
 
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * Represents a FluentMessage specifically
+ *
+ * @param <B> The type of ResultBuilder used by the FluentMessage
+ */
 public interface FluentMessage<B extends ResultBuilder> extends FluentEntry<B> {
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/identifier/FluentIdentifier.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/identifier/FluentIdentifier.java
@@ -1,10 +1,41 @@
 package net.quickwrite.fluent4j.ast.identifier;
 
+/**
+ * The FluentIdentifier interface represents an identifier.
+ * Identifiers are used to represent names or keys within the localization messages.
+ *
+ * @param <I> The type of the identifier
+ */
 public interface FluentIdentifier<I> {
+    /**
+     * Retrieves the simple form of the identifier.
+     * The simple form typically represents the short name or key.
+     *
+     * @return The simple form of the identifier
+     */
     I getSimpleIdentifier();
+
+    /**
+     * Retrieves the full form of the identifier.
+     * The full form may represent the complete identifier with any additional context or namespace.
+     *
+     * @return The full form of the identifier
+     */
     I getFullIdentifier();
 
+    /**
+     * Calculates the hash code of the identifier.
+     *
+     * @return The hash code of the identifier
+     */
     int hashCode();
 
+    /**
+     * Compares this identifier to the specified object for equality.
+     * Two identifiers are considered equal if their simple forms are equal.
+     *
+     * @param o The object to compare with
+     * @return true if the specified object is equal to this identifier, false otherwise
+     */
     boolean equals(final Object o);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/pattern/ArgumentList.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/pattern/ArgumentList.java
@@ -5,46 +5,163 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.math.BigDecimal;
 
+/**
+ * The ArgumentList interface represents a list of arguments used in Fluent4J patterns.
+ * ArgumentList provides methods to access and retrieve named and positional arguments.
+ *
+ * @param <B> The type of ResultBuilder used by the arguments
+ */
 public interface ArgumentList<B extends ResultBuilder> {
+    /**
+     * Retrieves the named argument with the specified name from the ArgumentList.
+     *
+     * @param name The name of the named argument
+     * @return The NamedArgument associated with the specified name, or null if not found
+     */
     NamedArgument<B> getArgument(final String name);
+
+    /**
+     * Retrieves the positional argument at the specified index from the ArgumentList.
+     *
+     * @param index The index of the positional argument
+     * @return The FluentPattern representing the positional argument, or null if not found
+     */
     FluentPattern<B> getArgument(final int index);
 
+    /**
+     * Creates an empty ArgumentList instance.
+     *
+     * @param <B> The type of ResultBuilder used by the ArgumentList
+     * @return An empty ArgumentList
+     */
     @SuppressWarnings("unchecked")
     static <B extends ResultBuilder> ArgumentList<B> empty() {
         return (ArgumentList<B>) ImmutableArgumentList.SELF;
     }
 
+    /**
+     * The Builder interface provides methods for building an ArgumentList.
+     * This interface extends the Builder pattern and acts as a fluent interface to add various types of arguments.
+     *
+     * @param <B> The type of ResultBuilder used by the Builder
+     */
     interface Builder<B extends ResultBuilder> extends net.quickwrite.fluent4j.util.Builder<ArgumentList<B>> {
+        /**
+         * Adds a named argument to the ArgumentList with the specified name.
+         *
+         * @param name     The name of the named argument
+         * @param argument The NamedArgument to be added
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final String name, final NamedArgument<B> argument);
 
+        /**
+         * Adds a named argument with a BigDecimal value to the ArgumentList.
+         *
+         * @param name   The name of the named argument
+         * @param number The BigDecimal value to be added
+         * @return the Builder instance for further building
+         */
         Builder<B> add(final String name, final BigDecimal number);
 
+        /**
+         * Adds a named argument with a long value to the ArgumentList.
+         *
+         * @param name   The name of the named argument
+         * @param number The long value to be added
+         * @return the Builder instance for further building
+         */
         Builder<B> add(final String name, final long number);
 
+        /**
+         * Adds a named argument with a double value to the ArgumentList.
+         *
+         * @param name   The name of the named argument
+         * @param number The double value to be added
+         * @return the Builder instance for further building
+         */
         Builder<B> add(final String name, final double number);
 
+        /**
+         * Adds a named argument with a String input to the ArgumentList.
+         *
+         * @param name  The name of the named argument
+         * @param input The String input to be added
+         * @return the Builder instance for further building
+         */
         Builder<B> add(final String name, final String input);
     }
 
+    /**
+     * The PlenaryBuilder interface extends the Builder interface and provides additional methods for building an ArgumentList.
+     * This interface acts as a fluent interface to add positional arguments.
+     *
+     * @param <B> The type of ResultBuilder used by the PlenaryBuilder
+     */
     interface PlenaryBuilder<B extends ResultBuilder> extends Builder<B> {
 
+        /**
+         * Adds a positional argument represented by a FluentPattern to the ArgumentList.
+         *
+         * @param argument The FluentPattern representing the positional argument
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final FluentPattern<B> argument);
 
+        /**
+         * Adds a positional argument with a BigDecimal value to the ArgumentList.
+         *
+         * @param number The BigDecimal value to be added
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final BigDecimal number);
 
+        /**
+         * Adds a positional argument with a long value to the ArgumentList.
+         *
+         * @param number The long value to be added
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final long number);
 
+        /**
+         * Adds a positional argument with a double value to the ArgumentList.
+         *
+         * @param number The double value to be added
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final double number);
 
+        /**
+         * Adds a positional argument with a String input to the ArgumentList.
+         *
+         * @param input The String input to be added
+         * @return The Builder instance for further building
+         */
         Builder<B> add(final String input);
     }
 
+    /**
+     * The NamedArgument interface represents a named argument used in Fluent4J patterns.
+     * NamedArgument extends FluentPattern and can be used in place of a FluentPattern in an ArgumentList.
+     *
+     * @param <B> The type of ResultBuilder used by the NamedArgument
+     */
     interface NamedArgument<B extends ResultBuilder> extends FluentPattern<B> {
 
     }
 }
 
+/**
+ * The ImmutableArgumentList class represents an immutable empty ArgumentList.
+ * It is used to provide an empty ArgumentList instance through the static empty() method in ArgumentList interface.
+ *
+ * @param <B> The type of ResultBuilder used by the ImmutableArgumentList
+ */
 class ImmutableArgumentList<B extends ResultBuilder> implements ArgumentList<B> {
+    /**
+     * An instance of ImmutableArgumentList to represent an empty ArgumentList.
+     */
     public static final ImmutableArgumentList<? extends ResultBuilder> SELF = new ImmutableArgumentList<>();
 
     @Override

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/placeable/FluentPlaceable.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/placeable/FluentPlaceable.java
@@ -3,8 +3,39 @@ package net.quickwrite.fluent4j.ast.placeable;
 import net.quickwrite.fluent4j.ast.FluentPattern;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The specific interface fot a placeable.
+ *
+ * <p>
+ *     In the default Fluent implementation a placeable
+ *     looks like this:
+ *     <pre>
+ *        placeable = { $var }
+ *     </pre>
+ * </p>
+ * @param <B> The scope that the placeable should use
+ */
 public interface FluentPlaceable<B extends ResultBuilder> extends FluentPattern<B> {
+    /**
+     * A specific interface that is being used to define that
+     * this element should behave like a placeable but shouldn't
+     * be directly used as a standard placeable: <br />
+     *
+     * This for example is being used as a way to limit the
+     * ability for a standard Fluent Term Attribute Reference
+     * to be used as a normal Placeable. Which means that this isn't possible:
+     * <pre>
+     *     attr-reference = {-test.attribute}
+     * </pre>
+     */
     interface CannotPlaceable {
+        /**
+         * Returns the name that should be used for the
+         * Exception that is being thrown because this cannot be
+         * used as a placeable.
+         *
+         * @return The name
+         */
         String getName();
     }
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/ast/placeable/FluentSelect.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/ast/placeable/FluentSelect.java
@@ -8,7 +8,30 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.util.function.Function;
 
+/**
+ * The Select Placeable that can be used as a Placeable in
+ * Fluent Documents.
+ *
+ * <p>
+ *     The default version of fluent has this type of Select Expression where
+ *     there are different Variants and a main selectable element that is being
+ *     switched upon.
+ *     <pre>
+ *         select = { $var ->
+ *              [hi] Hello
+ *              *[bye] Goodbye
+ *         }
+ *     </pre>
+ * </p>
+ *
+ * @param <B> The scope that the Select Placeable should use
+ */
 public interface FluentSelect<B extends ResultBuilder> extends FluentPlaceable<B> {
+    /**
+     * A single variant of the Select Placeable
+     *
+     * @param <B> The scope that the variant should use
+     */
     interface FluentVariant<B extends ResultBuilder> extends FluentResolvable<B> {
         FluentIdentifier<FluentVariantKey<B>> getIdentifier();
 
@@ -16,7 +39,20 @@ public interface FluentSelect<B extends ResultBuilder> extends FluentPlaceable<B
         }
     }
 
+    /**
+     * Defines if the element is selectable and how it should
+     * react to the different values.
+     *
+     * @param <B> The type of ResultBuilder associated with the resolvable entity.
+     */
     interface Selectable<B extends ResultBuilder> {
+        /**
+         * Returns a function that can be used to check if
+         * a Variant is the correct variant.
+         *
+         * @param scope The scope that the select checker should use
+         * @return A SelectChecker that can be used for the different variants
+         */
         Function<FluentVariant<B>, Boolean> selectChecker(final FluentScope<B> scope);
     }
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/container/FluentBundle.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/container/FluentBundle.java
@@ -4,32 +4,169 @@ import com.ibm.icu.util.ULocale;
 import net.quickwrite.fluent4j.ast.entry.FluentEntry;
 import net.quickwrite.fluent4j.ast.FluentFunction;
 import net.quickwrite.fluent4j.ast.pattern.ArgumentList;
-import net.quickwrite.fluent4j.parser.ResourceParser;
 import net.quickwrite.fluent4j.result.ResultBuilder;
-import net.quickwrite.fluent4j.util.Builder;
 
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * A collection of localization messages for a single locale, which are meant
+ * to be used together in a single view, widget or any other UI abstraction. <br />
+ * This also contains the different functions and other types of messages like
+ * terms as they are dependent on the locale.
+ *
+ * @param <B> The type of ResultBuilder associated with the resolvable entities.
+ */
 public interface FluentBundle<B extends ResultBuilder> {
+    /**
+     * Returns if the message with this specific
+     * key does exist.
+     *
+     * @param key The key to check against
+     * @return True if the message exist
+     */
     boolean hasMessage(final String key);
 
+    /**
+     * Returns a set of all messages with their
+     * respective key.
+     *
+     * @return All messages
+     */
     Set<Map.Entry<String, FluentEntry<B>>> getMessages();
 
+    /**
+     * Returns the message with the given key.
+     * <br />
+     * If the message doesn't exist it will return
+     * an empty optional.
+     *
+     * @param key The key of the message
+     * @return The message or an empty optional
+     */
     Optional<FluentEntry<B>> getMessage(final String key);
 
+    /**
+     * Returns the Builder itself that was being given
+     * which was being run over the entire tree of the
+     * message with the given key.
+     * <br />
+     * If the message doesn't exist it will return
+     * an empty optional.
+     *
+     * <p>
+     *     With that the message will be resolved and
+     *     converted into a format that is being
+     *     concatenated and can easily be used.
+     *     <br />
+     *     This means that the message will now use
+     *     terms, select expressions, variables etc.
+     *     to return a readable message that can
+     *     be used as a result.
+     * </p>
+     *
+     * @param key The key of the message
+     * @param argumentList A list of arguments
+     * @param builder The builder that should be used
+     * @return The builder or an empty optional
+     */
     Optional<B> resolveMessage(final String key, final ArgumentList<B> argumentList, final B builder);
+    /**
+     * Returns the Builder itself that was being given
+     * which was being run over the entire tree of the
+     * message with the given key.
+     * <br />
+     * If the message doesn't exist it will return
+     * an empty optional.
+     *
+     * <p>
+     *     With that the message will be resolved and
+     *     converted into a format that is being
+     *     concatenated and can easily be used.
+     *     <br />
+     *     This means that the message will now use
+     *     terms, select expressions, variables etc.
+     *     to return a readable message that can
+     *     be used as a result.
+     * </p>
+     * <p>
+     *     This will use an empty argument list
+     *     as the arguments.
+     * </p>
+     *
+     * @param key The key of the message
+     * @param builder The builder that should be used
+     * @return The builder or an empty optional
+     */
     Optional<B> resolveMessage(final String key, final B builder);
 
+    /**
+     * Returns all the entries of the specified class
+     * type as a set with their respective key.
+     *
+     * @param clazz The class that the entries should have
+     * @return All elements
+     * @param <T> The generic type that class can have
+     */
     <T extends FluentEntry<B>> Set<Map.Entry<String, FluentEntry<B>>> getEntries(final Class<T> clazz);
 
+    /**
+     * Returns a single entry with the specific key
+     * specified with that specific class.
+     * <br />
+     * If the entry doesn't exist it will return
+     * an empty optional.
+     *
+     * @param key The key of the entry
+     * @param clazz The class that the entry should have
+     * @return The entry or an empty optional
+     * @param <T> The generic type that class can have
+     */
     <T extends FluentEntry<B>> Optional<T> getEntry(final String key, final Class<T> clazz);
 
+    /**
+     * Returns the locale that this specific bundle
+     * has.
+     * <br />
+     * The bundle itself is being based around a single
+     * locale that all the messages, terms, functions etc.
+     * have.
+     *
+     * @return The locale of the bundle
+     */
     ULocale getLocale();
 
+    /**
+     * Returns the function with the specific key.
+     * <br />
+     * If the function doesn't exist it will return
+     * an empty optional.
+     *
+     * <p>
+     *     Function names normally only have
+     *     upper-case letters which means
+     *     that a function with the name of
+     *     {@code Test} is probably not valid and
+     *     with that not in this list.
+     * </p>
+     *
+     * @param key The key (aka. the name) of the function
+     * @return The function itself or an empty optional
+     */
     Optional<FluentFunction<B>> getFunction(final String key);
 
+    /**
+     * Returns all the functions as a set.
+     *
+     * <p>
+     *     As the functions store their name
+     *     themselves the set does not contain their
+     *     names.
+     * </p>
+     *
+     * @return All the functions
+     */
     Set<FluentFunction<B>> getFunctions();
 
     interface Builder<B extends ResultBuilder> extends net.quickwrite.fluent4j.util.Builder<FluentBundle<B>> {

--- a/api/src/main/java/net/quickwrite/fluent4j/container/FluentResource.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/container/FluentResource.java
@@ -5,8 +5,28 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.util.List;
 
+/**
+ * A resource containing a list of localization messages.
+ * <br />
+ * The different entries should all be of the same locale
+ * as they aren't directly categorized in this resource.
+ *
+ * @param <B> The type of ResultBuilder associated with the resolvable entities.
+ */
 public interface FluentResource<B extends ResultBuilder> {
+    /**
+     * Returns a list of all entries that are being contained
+     * in this resource.
+     *
+     * @return A list of all entries
+     */
     List<FluentEntry<B>> entries();
 
+    /**
+     * Returns a single entry at the given position.
+     *
+     * @param index The index of the entry
+     * @return A single entry
+     */
     FluentEntry<B> entry(final int index);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/container/FluentScope.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/container/FluentScope.java
@@ -6,18 +6,67 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.util.Set;
 
+/**
+ * This interface is a basic container for the resolving process
+ * of the messages which stores basic information that can be useful
+ * for the different components.
+ *
+ * @param <B> The type of ResultBuilder associated with the resolvable entities.
+ */
 public interface FluentScope<B extends ResultBuilder> extends Cloneable {
+
+    /**
+     * Retrieves the FluentBundle associated with this FluentScope.
+     *
+     * @return The FluentBundle associated with this FluentScope
+     */
     FluentBundle<B> bundle();
 
+    /**
+     * Retrieves the set of traversed FluentIdentifiers.
+     *
+     * @return The set of traversed FluentIdentifiers
+     */
     Set<FluentIdentifier<?>> traversed();
 
+    /**
+     * Adds a FluentIdentifier to the set of traversed identifiers.
+     *
+     * @param key the FluentIdentifier to add
+     * @return True if the FluentIdentifier was added successfully, false otherwise
+     */
     boolean addTraversed(final FluentIdentifier<?> key);
 
+    /**
+     * Returns the Arguments that were provided with this scope.
+     * <br />
+     * So with the top scope the arguments are the code provided
+     * arguments and with terms the arguments are the term provided
+     * arguments.
+     *
+     * @return The ArgumentList
+     */
     ArgumentList<B> arguments();
 
+    /**
+     * Sets the ArgumentList.
+     *
+     * @param arguments The ArgumentList to set
+     */
     void setArguments(final ArgumentList<B> arguments);
 
+    /**
+     * Returns the builder that is being used to build the resolved
+     * message itself.
+     *
+     * @return The ResultBuilder associated with this FluentScope
+     */
     B builder();
 
+    /**
+     * Creates and returns a clone of this FluentScope.
+     *
+     * @return A clone of this FluentScope
+     */
     FluentScope<B> clone();
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/iterator/ContentIterator.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/iterator/ContentIterator.java
@@ -1,14 +1,72 @@
 package net.quickwrite.fluent4j.iterator;
 
+/**
+ * The main iterator that the parsers are traversing
+ *
+ * <p>
+ *     This is being used as an abstraction for the
+ *     input of the parser as the input could be
+ *     everything from a File to a String.
+ * </p>
+ */
 public interface ContentIterator {
+    /**
+     * Returns the name of the input type and
+     * other information for more informational
+     * Exception messages.
+     *
+     * @return The name of the input
+     */
     String inputName();
 
+    /**
+     * Returns the current char as a codepoint
+     * that the iterator currently is at.
+     *
+     * @return The current character
+     */
     int character();
+
+    /**
+     * Returns the next char as a codepoint
+     * and increments the iterator.
+     *
+     * @return The next char
+     */
     int nextChar();
 
+    /**
+     * Returns the current line that the
+     * input currently is at.
+     *
+     * @return The current line
+     */
     String line();
+
+    /**
+     * Returns the next line that the input
+     * is currently at and increments the
+     * iterator accordingly.
+     *
+     * @return The next line
+     */
     String nextLine();
 
+    /**
+     * Returns the current position based on
+     * the current line and the current line
+     * position.
+     *
+     * @return The current position
+     */
     int[] position();
+
+    /**
+     * Sets the current position based on the
+     * line and the current line position
+     *
+     * @param position The position that the iterator should
+     *                 be changed to
+     */
     void setPosition(final int[] position);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/FluentParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/FluentParser.java
@@ -2,6 +2,12 @@ package net.quickwrite.fluent4j.parser;
 
 import net.quickwrite.fluent4j.iterator.ContentIterator;
 
+/**
+ * The basic parser interface
+ *
+ * @param <T> The element that should be returned
+ *           by the parser
+ */
 public interface FluentParser<T> {
 
     T parse(final ContentIterator iterator);

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/ResourceParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/ResourceParser.java
@@ -5,6 +5,11 @@ import net.quickwrite.fluent4j.container.FluentResource;
 import net.quickwrite.fluent4j.parser.base.FluentElementParser;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The parser that is parsing an entire Resource from start to end.
+ *
+ * @param <B> The Builder that is being used to parse this resource
+ */
 public interface ResourceParser<B extends ResultBuilder> extends FluentParser<FluentResource<B>> {
 
     interface Builder<B extends ResultBuilder> extends net.quickwrite.fluent4j.util.Builder<ResourceParser<B>> {

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/base/FluentElementParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/base/FluentElementParser.java
@@ -5,7 +5,24 @@ import net.quickwrite.fluent4j.parser.FluentParser;
 import net.quickwrite.fluent4j.parser.result.ParseResult;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The parser for the basis of the file.
+ * They are parsing the topdown elements that are directly
+ * being used in the {@link net.quickwrite.fluent4j.container.FluentBundle}.
+ *
+ * <p>
+ * These parsers are for example parsing the comments,
+ * messages, terms, etc.
+ * </p>
+ *
+ * @param <T>
+ */
 public interface FluentElementParser<T> extends FluentParser<ParseResult<T>> {
+    /**
+     * An interface for providing a list as an easy bridge
+     * between implementation and the interface. It can be used
+     * to simplify the building step of the parser.
+     */
     interface FluentElementParserList {
         <B extends ResultBuilder> FluentElementParser<? extends FluentEntry<B>> getParser();
     }

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/FluentContentParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/FluentContentParser.java
@@ -7,7 +7,22 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 import java.util.List;
 import java.util.function.Function;
 
+/**
+ * A list of parsers for parsing the contents of a message
+ *
+ * @param <B> The Builder that is being used to parse this resource
+ */
 public interface FluentContentParser<B extends ResultBuilder> {
+    /**
+     * Parses the content of an element into a list of {@link FluentPattern}
+     * until it reaches the end of the input determined either by the
+     * {@code iterator} or by the {@code endChecker}.
+     *
+     * @param iterator The iterator that the parser should run over
+     * @param endChecker The function that determines if the current
+     *                   state of the iterator is defined as the end
+     * @return A list of the parsed {@link FluentPattern}
+     */
     List<FluentPattern<B>> parse(final ContentIterator iterator, final Function<ContentIterator, Boolean> endChecker);
 
     interface Builder<B extends ResultBuilder> extends net.quickwrite.fluent4j.util.Builder<FluentContentParser<B>> {

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/FluentPatternParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/FluentPatternParser.java
@@ -5,8 +5,37 @@ import net.quickwrite.fluent4j.iterator.ContentIterator;
 import net.quickwrite.fluent4j.parser.result.ParseResult;
 import net.quickwrite.fluent4j.result.ResultBuilder;
 
+/**
+ * The basic pattern parser interface
+ *
+ * <p>
+ *     A pattern itself is a component of the content
+ *     of a message. E. g.:
+ *     <pre>
+ *         message = pattern { $pattern2 }
+ *     </pre>
+ * </p>
+ *
+ * @param <T> The resulting pattern
+ * @param <B> The Builder that is being used to parse this resource
+ */
 public interface FluentPatternParser<T extends FluentPattern<B>, B extends ResultBuilder> {
+    /**
+     * Returns the starting character of the component
+     *
+     * @return The starting char
+     */
     int getStartingChar();
 
+    /**
+     * Returns the parsed version of the next iterator
+     * sequence for the specific pattern.
+     *
+     * @param iterator The iterator that should be parsed
+     * @param contentParser The parser that can be used to
+     *                      recursively parse the content like
+     *                      the message content
+     * @return The result of the parsing operation
+     */
     ParseResult<T> parse(final ContentIterator iterator, final FluentContentParser<B> contentParser);
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/placeable/PlaceableExpressionParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/placeable/PlaceableExpressionParser.java
@@ -6,6 +6,19 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.util.Optional;
 
+/**
+ * The parser for the actual different Placeables.
+ *
+ * <p>
+ *     This parser should only parse from the actual start of
+ *     the element inside of the Placeable and not the start of
+ *     the placeable itself.
+ *     <br />
+ *     For example with the placeable {@code { 42 } } it would
+ *     parse from the {@code 4} to the {@code }} and close it.
+ * </p>
+ * @param <B> The Builder that is being used to parse this resource
+ */
 public interface PlaceableExpressionParser<B extends ResultBuilder> {
     Optional<FluentPlaceable<B>> parse(final ContentIterator iterator, final PlaceableParser<B> placeableParser);
 

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/placeable/PlaceableParser.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/pattern/placeable/PlaceableParser.java
@@ -9,6 +9,18 @@ import net.quickwrite.fluent4j.result.ResultBuilder;
 
 import java.util.Optional;
 
+/**
+ * The raw interface for the parser that parses
+ * any type of Placeable and returns the correct implementation
+ * of that Placeable.
+ *
+ * <p>
+ *     So the Parser would parse {@code { 5 }} and would output
+ *     a NumberLiteral and if it would parse {@code { "Hello" }}
+ *     it would return a StringLiteral.
+ * </p>
+ * @param <B> The Builder that is being used to parse this resource
+ */
 public interface PlaceableParser<B extends ResultBuilder> extends FluentPatternParser<FluentPattern<B>, B> {
     Optional<FluentPlaceable<B>> parsePlaceable(final ContentIterator iterator);
 

--- a/api/src/main/java/net/quickwrite/fluent4j/parser/result/ParseResult.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/parser/result/ParseResult.java
@@ -1,6 +1,59 @@
 package net.quickwrite.fluent4j.parser.result;
 
+/**
+ * The result of a parsing step.
+ *
+ * <p>
+ *     The result of the parsing step can be divided into
+ *     three different results:
+ *     <ol type="1">
+ *         <li>
+ *             {@code Success} which indicates that there is a
+ *              valid result of this parsing step.
+ *
+ *              <br />
+ *
+ *              The result of this parsing step also contains
+ *              the resulting object that was being generated
+ *              by this.
+ *         </li>
+ *         <li>
+ *             {@code Skip} which indicates that the parsing was
+ *              successful but didn't have any result.
+ *
+ *              <br />
+ *
+ *              The result in this case is {@code null}.
+ *         </li>
+ *         <li>
+ *             {@code Failure} which indicates that the parsing
+ *             step didn't go as planned and needs to be either
+ *             reevaluated to ditched completely.
+ *
+ *             <br />
+ *
+ *             The result in this case is {@code null}.
+ *         </li>
+ *     </ol>
+ * </p>
+ *
+ * <p>
+ *     This is similar to the {@link java.util.Optional} but it has the
+ *     key difference that this object has three different states instead
+ *     of just two.
+ * </p>
+ * @param <T> The value type that the result should have
+ *           if it was successful
+ */
 public interface ParseResult<T> {
+    /**
+     * Create a successful parsing result
+     *
+     * @param value The value that should be returned
+     * @return A {@link ParseResult} that contains the value
+     *         and indicates that this was successful
+     * @param <V> The type of the resulting value
+     */
     static <V> ParseResult<V> success(final V value) {
         return new ParseResult<>() {
             @Override
@@ -15,23 +68,109 @@ public interface ParseResult<T> {
         };
     }
 
+    /**
+     * Returns a simple failure parse result
+     *
+     * <p>
+     *     This can indicate that something went wrong
+     *     while parsing or the parser is not the correct
+     *     parser for this section
+     * </p>
+     *
+     * @return The parse result that indicates a failure
+     * @param <V> The value type that the result should have
+     *           if it was successful
+     */
     @SuppressWarnings("unchecked")
     static <V> ParseResult<V> failure() {
         return (ParseResult<V>) ParseResultType.FAILURE_IMPL;
     }
 
+    /**
+     * Returns a simple skip parse result
+     *
+     * @return The parse result that indicates a skip
+     * @param <V> The value type that the result should have
+     *           if it was successful
+     */
     @SuppressWarnings("unchecked")
     static <V> ParseResult<V> skip() {
         return (ParseResult<V>) ParseResultType.SKIP_IMPL;
     }
 
+    /**
+     * Returns the type that the ParseResult contains
+     *
+     * @return The type of the ParseResult
+     */
     ParseResultType getType();
 
+    /**
+     * Returns the value of the ParseResult if it is
+     * successful.
+     *
+     * <p>
+     *     If it wasn't a successful ParseResult
+     *     it is going to return a {@code null} value.
+     * </p>
+     *
+     * @return The value of the ParseResult
+     */
     T getValue();
 
+    /**
+     * The result types of the parsing step can be indicated by these
+     * different types of the result:
+     * <ol type="1">
+     *     <li>
+     *         {@code Success} which indicates that there is a
+     *          valid result of this parsing step.
+     *
+     *          <br />
+     *
+     *          The result of this parsing step also contains
+     *          the resulting object that was being generated
+     *          by this.
+     *     </li>
+     *     <li>
+     *         {@code Skip} which indicates that the parsing was
+     *          successful but didn't have any result.
+     *
+     *          <br />
+     *
+     *          The result in this case is {@code null}.
+     *     </li>
+     *     <li>
+     *         {@code Failure} which indicates that the parsing
+     *         step didn't go as planned and needs to be either
+     *         reevaluated to ditched completely.
+     *
+     *         <br />
+     *
+     *         The result in this case is {@code null}.
+     *     </li>
+     * </ol>
+     */
     enum ParseResultType {
+        /**
+         * This indicates that the parsing step was
+         * successful and a result was being created
+         */
         SUCCESS,
+
+        /**
+         * This indicates that the parsing step was
+         * successful but no result was being created
+         * and this part should just be skipped
+         */
         SKIP,
+
+        /**
+         * This indicates that the parsing step wasn't
+         * successful and this part either needs to be
+         * reevaluated or the parsing should be discontinued
+         * entirely.
+         */
         FAILURE;
 
         static final ParseResult<?> FAILURE_IMPL = new ParseResult<>() {

--- a/api/src/main/java/net/quickwrite/fluent4j/result/ResultBuilder.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/result/ResultBuilder.java
@@ -1,11 +1,40 @@
 package net.quickwrite.fluent4j.result;
 
+/**
+ * The ResultBuilder interface is represents a way to
+ * combine all the different elements of a message for a
+ * simple result.
+ */
 public interface ResultBuilder {
+    /**
+     * Appends a sequence to the result.
+     *
+     * @param sequence the sequence to append
+     * @return the ResultBuilder instance
+     */
     ResultBuilder append(final CharSequence sequence);
 
+    /**
+     * Appends a character to the result.
+     *
+     * @param character the character to append
+     * @return the ResultBuilder instance
+     */
     ResultBuilder append(final char character);
 
-    ResultBuilder append(final int character);
+    /**
+     * Appends a Unicode code point as a character to the result.
+     *
+     * @param codePoint the Unicode code point representing a character to append
+     * @return the ResultBuilder instance
+     */
+    ResultBuilder append(final int codePoint);
 
+    /**
+     * Retrieves a simple builder for accumulating strings in a tree traversal.
+     *
+     * @param <T> the type of the simple builder
+     * @return the simple builder instance
+     */
     <T extends ResultBuilder> T getSimpleBuilder();
 }

--- a/api/src/main/java/net/quickwrite/fluent4j/util/Builder.java
+++ b/api/src/main/java/net/quickwrite/fluent4j/util/Builder.java
@@ -2,15 +2,21 @@ package net.quickwrite.fluent4j.util;
 
 import java.util.function.Consumer;
 
+/**
+ * The Builder interface represents a generic builder.
+ *
+ * @param <R> the type to be built
+ */
 public interface Builder<R> {
+
     /**
-     * Configures {@code builder} using {@code consumer} and then builds.
+     * Configures the builder using the provided consumer and then builds the object.
      *
-     * @param builder the builder
-     * @param consumer the builder consume
-     * @param <R> the type to be built
-     * @param <B> the builder type
-     * @return the built thing
+     * @param builder  the builder instance
+     * @param consumer the consumer to configure the builder
+     * @param <R>      the type to be built
+     * @param <B>      the builder type
+     * @return the built object
      */
     static <R, B extends Builder<R>> R configureAndBuild(final B builder, final Consumer<? super B> consumer) {
         if (consumer != null) {
@@ -19,5 +25,10 @@ public interface Builder<R> {
         return builder.build();
     }
 
+    /**
+     * Builds the object.
+     *
+     * @return the built object
+     */
     R build();
 }


### PR DESCRIPTION
JavaDocs, short for Java Documentation, are an essential component of any Java project. They provide a standardized way to document the purpose, functionality, and usage of classes, interfaces, methods, and other elements within the codebase. While the primary audience for JavaDocs is developers, their importance extends far beyond that. Here are several reasons why JavaDocs are crucial for this project:
1. Enhancing Code Understanding: JavaDocs serve as a comprehensive reference manual for developers working on a project. They provide detailed information about classes, methods, and their parameters, return types, exceptions, and more. By reading the JavaDocs, developers can quickly grasp the intended purpose and behavior of each component, leading to improved code comprehension.
2. API Documentation for Users: JavaDocs are beneficial for users of an API or library. By generating comprehensive JavaDocs, developers provide a user-friendly guide for utilizing the provided functionality. Users can understand the available classes, methods, and their usage, enabling them to integrate the codebase seamlessly into their own projects.